### PR TITLE
Fix search engine redirection issue

### DIFF
--- a/linkify.js
+++ b/linkify.js
@@ -15,10 +15,27 @@ function redirectGoLink(details) {
     return {redirectUrl: local_storage_cache[golink].url}
 }
 
+function redirectSearchLink(details) {
+    let golink = details.url.replace(/(.*)\:\/\/(.*)=go%2F/, "")
+    const regex = /%2F/g;
+    golink =  golink.replace(regex, "/");
+    golink = golink.replace(/\&fr=opensearch|\&addon=opensearch/, "")
+    if (!local_storage_cache[golink]) {
+        return;
+    }
+    return {redirectUrl: local_storage_cache[golink].url}
+}
+
 browser.storage.onChanged.addListener(() => getLocalStorageData());
 
 browser.webRequest.onBeforeRequest.addListener(
     redirectGoLink,
     { "urls": ["*://go/*"] },
+    ["blocking"],
+);
+
+browser.webRequest.onBeforeRequest.addListener(
+    redirectSearchLink,
+    { "urls": ["*://*/*=go%2F*"] },
     ["blocking"],
 );

--- a/linkify.js
+++ b/linkify.js
@@ -15,11 +15,17 @@ function redirectGoLink(details) {
     return {redirectUrl: local_storage_cache[golink].url}
 }
 
+/**
+ * Extract the go link from the search link and redirect to the user's stored website if exists.
+ */
 function redirectSearchLink(details) {
     let golink = details.url.replace(/(.*)\:\/\/(.*)=go%2F/, "")
-    const regex = /%2F/g;
-    golink =  golink.replace(regex, "/");
+    golink = golink.replace(/%2F/, "/");
+
+    // Remove trailing query string content of the search link
+    // Yahoo: &fr=opensearch, Ecosia: &addon=opensearch
     golink = golink.replace(/\&fr=opensearch|\&addon=opensearch/, "")
+
     if (!local_storage_cache[golink]) {
         return;
     }

--- a/linkify.js
+++ b/linkify.js
@@ -20,7 +20,8 @@ function redirectGoLink(details) {
  */
 function redirectSearchLink(details) {
     let golink = details.url.replace(/(.*)\:\/\/(.*)=go%2F/, "")
-    golink = golink.replace(/%2F/, "/");
+    // Global flag g is included to replace all "%2F" with "/"
+    golink = golink.replace(/%2F/g, "/");
 
     // Remove trailing query string content of the search link
     // Yahoo: &fr=opensearch, Ecosia: &addon=opensearch
@@ -42,6 +43,6 @@ browser.webRequest.onBeforeRequest.addListener(
 
 browser.webRequest.onBeforeRequest.addListener(
     redirectSearchLink,
-    { "urls": ["*://*/*=go%2F*"] },
+    { "urls": ["*://*.google.com/*=go%2F*", "*://*.yahoo.com/*=go%2F*", "*://*.bing.com/*=go%2F*", "*://*.duckduckgo.com/*=go%2F*", "*://*.ecosia.org/*=go%2F*", "*://*.baidu.com/*=go%2F*"] },
     ["blocking"],
 );

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Go Links",
-    "version": "0.0.2",
+    "version": "0.0.3",
 
     "description": "Fast accessing your websites with a personal URL shortener",
 


### PR DESCRIPTION
Firefox prioritizes search engine over URL when using the address bar, which will use the search engine to "search" for the go link (go/example) instead of using the URL "http://go/example".

This fix aims to handle these default search engines:  Google, Bing, Yahoo, Baidu, DuckDuckGo, Ecosia